### PR TITLE
fix: add ".js" extension to StringUtils import

### DIFF
--- a/src/snake-naming.strategy.ts
+++ b/src/snake-naming.strategy.ts
@@ -2,7 +2,7 @@
 // https://gist.github.com/recurrence/b6a4cb04a8ddf42eda4e4be520921bd2
 
 import { DefaultNamingStrategy, NamingStrategyInterface } from 'typeorm';
-import { snakeCase } from 'typeorm/util/StringUtils';
+import { snakeCase } from 'typeorm/util/StringUtils.js';
 
 export class SnakeNamingStrategy
   extends DefaultNamingStrategy


### PR DESCRIPTION
This change adds a ".js" file extension to the "StringUtils" import, which makes this project compatible with ESM projects.

Without this change, if you try building with an ESM project you will get the error:
```
Error: Cannot find module 'MyProject\node_modules\typeorm\util\StringUtils'
    at createEsmNotFoundErr (node:internal/modules/cjs/loader:954:15)
    at finalizeEsmResolution (node:internal/modules/cjs/loader:947:15)
    at resolveExports (node:internal/modules/cjs/loader:482:14)
    at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (MyProject\node_modules\typeorm-naming-strategies\snake-naming.strategy.js:5:23)
    at Module._compile (node:internal/modules/cjs/loader:1097:14) {
  code: 'MODULE_NOT_FOUND',
  path: 'MyProject\\node_modules\\typeorm\\package.json'
}
```