### PR TITLE
fix: Remove ".js" extension to StringUtils import

### DIFF
--- a/src/snake-naming.strategy.ts
+++ b/src/snake-naming.strategy.ts
@@ -2,7 +2,7 @@
 // https://gist.github.com/recurrence/b6a4cb04a8ddf42eda4e4be520921bd2
 
 import { DefaultNamingStrategy, NamingStrategyInterface } from 'typeorm';
-import { snakeCase } from 'typeorm/util/StringUtils.js';
+import { snakeCase } from 'typeorm/util/StringUtils';
 
 export class SnakeNamingStrategy
   extends DefaultNamingStrategy


### PR DESCRIPTION
fix #22 

With the last update of typeorm, by default the project is compatible with ESM projects, so this `.js` at the end of the import introduces the following error when used with `typeorm: "^0.2.45"`

```
ERROR	Error: Cannot find module '/var/task/node_modules/typeorm/util/StringUtils.js.js'
    at createEsmNotFoundErr (internal/modules/cjs/loader.js:929:15)
    at finalizeEsmResolution (internal/modules/cjs/loader.js:922:15)
    at resolveExports (internal/modules/cjs/loader.js:450:14)
    at Function.Module._findPath (internal/modules/cjs/loader.js:490:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:888:27)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/var/task/node_modules/typeorm-naming-strategies/snake-naming.strategy.js:5:26)
    at Module._compile (internal/modules/cjs/loader.js:1085:14) {
  code: 'MODULE_NOT_FOUND',
  path: '/var/task/node_modules/typeorm/package.json'
}
```