### PR TITLE
feat: indicate support for TypeORM 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "typeorm": "^0.2.0"
+    "typeorm": "^0.2.0 || ^0.3.0"
   }
 }


### PR DESCRIPTION
TypeORM 0.3 is out which causes a dependency resolution error. The only changes made to `NamingStrategyInterface` were cosmetic (see: https://github.com/typeorm/typeorm/commit/3b8a031ece508820651a3a8f99f9cbf87319812c#diff-e79be82198697dd3457ea7de2814de673e585dbb1b2169c478ece119fd2ec9d7) and tests seem to pass when running them against 0.3.0.

![Screen Shot 2022-03-18 at 10 59 26 AM](https://user-images.githubusercontent.com/20146550/158901587-935fba4d-3332-49e9-b79f-3eff7923f9ab.png)

