### PR TITLE
Remove `classTableInheritanceParentColumnName`

### DIFF
--- a/src/snake-naming.strategy.ts
+++ b/src/snake-naming.strategy.ts
@@ -55,13 +55,6 @@ export class SnakeNamingStrategy
     );
   }
 
-  classTableInheritanceParentColumnName(
-    parentTableName: any,
-    parentTableIdPropertyName: any,
-  ): string {
-    return snakeCase(parentTableName + '_' + parentTableIdPropertyName);
-  }
-
   eagerJoinRelationAlias(alias: string, propertyPath: string): string {
     return alias + '__' + propertyPath.replace('.', '_');
   }


### PR DESCRIPTION
`classTableInheritanceParentColumnName` was removed from `NamingStrategyInterface` in the TypeORM 0.2.0 release

See https://github.com/typeorm/typeorm/commit/2a0ae48dac7ab8230977d8a8bf7401b237ba85d7#diff-e79be82198697dd3457ea7de2814de673e585dbb1b2169c478ece119fd2ec9d7L74