### PR TITLE
Optimize Naming Strategy for Pluralized Tables and Singular Columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,16 @@
 {
   "name": "typeorm-naming-strategies",
-  "version": "2.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.0",
+      "name": "typeorm-naming-strategies",
+      "version": "4.1.0",
       "license": "MIT",
+      "dependencies": {
+        "pluralize": "^8.0.0"
+      },
       "devDependencies": {
         "@types/jest": "^26.0.19",
         "@types/node": "^14.6.2",
@@ -17,7 +21,7 @@
         "typescript": "^4.0.2"
       },
       "peerDependencies": {
-        "typeorm": "^0.2.0"
+        "typeorm": "^0.2.0 || ^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -858,7 +862,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2536,8 +2539,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -4546,7 +4548,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -6932,6 +6933,15 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/posix-character-classes": {
@@ -14828,6 +14838,11 @@
           "peer": true
         }
       }
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   },
   "peerDependencies": {
     "typeorm": "^0.2.0 || ^0.3.0"
+  },
+  "dependencies": {
+    "pluralize": "^8.0.0"
   }
 }

--- a/src/snake-naming.strategy.ts
+++ b/src/snake-naming.strategy.ts
@@ -1,6 +1,7 @@
 // Credits to @recurrence
 // https://gist.github.com/recurrence/b6a4cb04a8ddf42eda4e4be520921bd2
 
+import pluralize from 'pluralize';
 import { DefaultNamingStrategy, NamingStrategyInterface } from 'typeorm';
 import { snakeCase } from 'typeorm/util/StringUtils';
 
@@ -8,7 +9,7 @@ export class SnakeNamingStrategy
   extends DefaultNamingStrategy
   implements NamingStrategyInterface {
   tableName(className: string, customName: string): string {
-    return customName ? customName : snakeCase(className);
+    return pluralize(customName ? customName : snakeCase(className));
   }
 
   columnName(
@@ -27,7 +28,9 @@ export class SnakeNamingStrategy
   }
 
   joinColumnName(relationName: string, referencedColumnName: string): string {
-    return snakeCase(relationName + '_' + referencedColumnName);
+    return snakeCase(
+      pluralize.singular(relationName) + '_' + referencedColumnName,
+    );
   }
 
   joinTableName(
@@ -37,11 +40,7 @@ export class SnakeNamingStrategy
     secondPropertyName: string,
   ): string {
     return snakeCase(
-      firstTableName +
-        '_' +
-        firstPropertyName.replace(/\./gi, '_') +
-        '_' +
-        secondTableName,
+      firstTableName + '_' + secondTableName.replace(/\./gi, '_'),
     );
   }
 
@@ -51,7 +50,9 @@ export class SnakeNamingStrategy
     columnName?: string,
   ): string {
     return snakeCase(
-      tableName + '_' + (columnName ? columnName : propertyName),
+      pluralize.singular(tableName) +
+        '_' +
+        (columnName ? columnName : propertyName),
     );
   }
 


### PR DESCRIPTION
#### Introduction
This pull request aims to enhance our database schema by implementing a consistent naming strategy. By adopting pluralized table names and singular column names, we can improve clarity and maintainability while aligning with industry best practices.

#### Naming strategy improvements: plural tables and singular columns
![singular-tables](https://github.com/user-attachments/assets/90ec5e48-ad2a-4a43-a633-37b404ef0993)

- Ensure that the names of the join tables are plural.
- Avoid duplication in table names.
![plural-tables](https://github.com/user-attachments/assets/f53da81f-230b-4b81-b816-d9a279ef0ac7)
- Columns in join tables are now singular.
![singular-columns](https://github.com/user-attachments/assets/6336ebbf-bbf4-4141-8e48-ae99c81d46f9)
